### PR TITLE
Overwrite loggedOut instead of logout in LoginController

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -63,18 +63,13 @@ class LoginController extends Controller
     }
 
     /**
-     * Log the user out and redirect him to specific location.
+     * The user has logged out of the application.
      *
-     * @param \Illuminate\Http\Request $request
-     *
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request $request
+     * @return mixed
      */
-    public function logout(Request $request)
+    protected function loggedOut(Request $request)
     {
-        // Do the default logout procedure
-        $this->guard()->logout();
-
-        // And redirect to custom location
         return redirect($this->redirectAfterLogout);
     }
 


### PR DESCRIPTION
In laravel 5.6.27, there is a `loggedOut` function been added in the `LoginController` which for the logics those after user logout, and since we depend on the laravel version higher or equal than 5.8, so it's safe to overwrite `loggedOut` instead of `logout` function.